### PR TITLE
Fix error type

### DIFF
--- a/gen-ssp/fixture/app-bridge/index.ts
+++ b/gen-ssp/fixture/app-bridge/index.ts
@@ -58,7 +58,9 @@ export const requestRiiidBrowserService: RequestFn = async (id, method, message)
     const response = await browserServiceMethodTable[method](message);
     appBridge.respondBrowserService(id, response);
   } catch (error) {
-    appBridge.respondErrorBrowserService(id, error?.message ?? 'error');
+    if (error instanceof Error) {
+      appBridge.respondErrorBrowserService(id, error.message ?? 'error');
+    }
   }
 };
 


### PR DESCRIPTION
Catch error type is set to default unknown in typescript@^4.4.
Add Error type guard