### PR TITLE
Update deno-version for CVE-2022-24783

### DIFF
--- a/actions/setup-gen-ssp/action.yml
+++ b/actions/setup-gen-ssp/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: denoland/setup-deno@v1
       with:
-        deno-version: v1.19.0
+        deno-version: v1.20.3
     - uses: actions/checkout@v2
       with:
         repository: riiid/toolbelt


### PR DESCRIPTION
According to the https://github.com/denoland/deno/security/advisories/GHSA-838h-jqp6-cf2f, a malicious actor controlling the code executed in a Deno runtime could bypass permission checks and execute arbitrary shell code.

This security advisory will be amended with more information about the vulnerability in a couple of days.