### PR TITLE
Upgrade deno version

### DIFF
--- a/actions/setup-gen-ssp/action.yml
+++ b/actions/setup-gen-ssp/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: denoland/setup-deno@v1
       with:
-        deno-version: v1.20.3
+        deno-version: v1.29.4
     - uses: actions/checkout@v2
       with:
         repository: riiid/toolbelt


### PR DESCRIPTION
- [`spec-fetcher`](https://github.com/riiid/riiidx/tree/main/src/team/component/santa/spec-fetcher)가 현재 버전의 deno에서 정상 동작하지 않아서, 이참에 최신 버전으로 업그레이드 해줍니다.